### PR TITLE
feat: upgrade androidx.window to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.20] - 2025-09-01
+
+### Changed
+
+- **BREAKING**: Migrated from deprecated `androidx.window.WindowManager` to `androidx.window.layout.WindowMetricsCalculator`
+- Updated androidx.window dependency from `1.0.0-alpha09` to `1.4.0` to resolve Google Play Store deprecation warning
+- Replaced `windowManager.getCurrentWindowMetrics()` with `windowMetricsCalculator.computeCurrentWindowMetrics(requireActivity())`
+
+### Fixed
+
+- Fixed Google Play Console warning: "Your app uses an outdated SDK version of androidx.window:window"
+- Resolved compatibility issues with Android API levels by using stable androidx.window APIs
+
 ## [0.0.19] - 2025-03-14
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation "androidx.camera:camera-view:$camerax_version"
 
     //WindowManager
-    implementation 'androidx.window:window:1.0.0-alpha09'
+    implementation 'androidx.window:window:1.4.0'
 
     // Unit Testing
     testImplementation "junit:junit:$junitVersion"

--- a/android/src/main/java/io/numbersprotocol/capturelite/plugins/previewcamera/PreviewCameraFragment.kt
+++ b/android/src/main/java/io/numbersprotocol/capturelite/plugins/previewcamera/PreviewCameraFragment.kt
@@ -23,7 +23,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import androidx.window.WindowManager
+import androidx.window.layout.WindowMetricsCalculator
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import io.numbersprotocol.capturelite.plugins.previewcamera.databinding.FragmentPreviewCameraBinding
@@ -72,7 +72,7 @@ class PreviewCameraFragment : Fragment() {
 
     private var camera: Camera? = null
     private var cameraProvider: ProcessCameraProvider? = null
-    private lateinit var windowManager: WindowManager
+    private lateinit var windowMetricsCalculator: WindowMetricsCalculator
 
     private var currentDisplayOrientation = 0;
 
@@ -182,8 +182,8 @@ class PreviewCameraFragment : Fragment() {
         // Every time the orientation of device changes, update rotation for use cases
 //        displayManager.registerDisplayListener(displayListener, null)
 
-        //Initialize WindowManager to retrieve display metrics
-        windowManager = WindowManager(view.context)
+        //Initialize WindowMetricsCalculator to retrieve display metrics
+        windowMetricsCalculator = WindowMetricsCalculator.getOrCreate()
 
         // Determine the output directory
 
@@ -473,7 +473,7 @@ class PreviewCameraFragment : Fragment() {
 
     fun focus(x: Float, y: Float) {
         // Get screen metrics used to setup camera for full screen resolution
-        val metrics = windowManager.getCurrentWindowMetrics().bounds
+        val metrics = windowMetricsCalculator.computeCurrentWindowMetrics(requireActivity()).bounds
         val factory: MeteringPointFactory = SurfaceOrientedMeteringPointFactory(
             metrics.width().toFloat(), metrics.height().toFloat()
         )
@@ -497,7 +497,7 @@ class PreviewCameraFragment : Fragment() {
     fun bindCameraUseCases(customScreenOrientation: Int = Surface.ROTATION_0) {
 
         // Get screen metrics used to setup camera for full screen resolution
-        val metrics = windowManager.getCurrentWindowMetrics().bounds
+        val metrics = windowMetricsCalculator.computeCurrentWindowMetrics(requireActivity()).bounds
 
         Log.d(TAG, "Screen metrics: ${metrics.width()} x ${metrics.height()}")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numbersprotocol/preview-camera",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numbersprotocol/preview-camera",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numbersprotocol/preview-camera",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Preview Camera Plugin for iOS, Android",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Ref numbersprotocol/capture-cam#3340

BREAKING CHANGE: Replace deprecated WindowManager with
                 WindowMetricsCalculator

- Update androidx.window dependency from 1.0.0-alpha09 to 1.4.0
- Migrate from androidx.window.WindowManager to androidx.window.layout.WindowMetricsCalculator
- Replace windowManager.getCurrentWindowMetrics() with windowMetricsCalculator.computeCurrentWindowMetrics( requireActivity())
- Fix Google Play Console warning about outdated SDK version
- Improve compatibility with latest Android API levels